### PR TITLE
Fix formatting error

### DIFF
--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ await message.ack()
 ### Get headers 
 Get headers per message
 
-``python
+```python
 headers = message.get_headers()
 ```
 


### PR DESCRIPTION
A backtack was missing in one of the Markdown code blocks, causing the code snippet to fail to render.