### PR TITLE
Added new code to fix consumer destroy

### DIFF
--- a/memphis/consumer.py
+++ b/memphis/consumer.py
@@ -43,6 +43,7 @@ class Consumer:
         self.context = {}
         self.dls_messages = []
         self.dls_current_index = 0
+        self.t_consume = None
         self.dls_callback_func = None
         self.t_dls = asyncio.create_task(self.__consume_dls())
 

--- a/memphis/memphis.py
+++ b/memphis/memphis.py
@@ -505,6 +505,7 @@ class Memphis:
             real_name = consumer_name.lower()
             if generate_random_suffix:
                 consumer_name = self.__generateRandomSuffix(consumer_name)
+                real_name += "_" + consumer_name.split("_")[-1]
             cg = consumer_name if not consumer_group else consumer_group
 
             if start_consume_from_sequence <= 0:


### PR DESCRIPTION
Hello! Thank you for your awesome project!
I found two problems with the consumer shutdown.

Firstly, there is an error if you want to destroy consumer, but you decided to use the method `fetch` instead of consume:
```
AttributeError: 'Consumer' object has no attribute 't_consume'
```
It occurs because this variable will be set only if the client-side application calls `consume`.  
  
Secondly, if you are using the `generate_random_suffix` parameter for consumer constructor `await memphis.consumer(generate_random_suffix=True, ...)` memphis add a key with name without suffix in consumer name - `self.consumers_map[map_key] = consumer`, `map_key` here is default name without suffix, so, when consumer tries to destroy an error occurs:
```
memphis.exceptions.MemphisError: memphis: 'taskiq_test_taskiq_consume_135a4cea'
```
Error is Implicit but I found that error was raised here:
```
# consumer, line 189
del self.connection.consumers_map[map_key]
```