### PR TITLE
Fix : no-member error for Exception status_code member (#1)

### DIFF
--- a/memphis/producer.py
+++ b/memphis/producer.py
@@ -265,13 +265,12 @@ class Producer:
                         schemaverse_fail_alert_type,
                     )
             raise e
-        except Exception as e:
+        except Exception as e: # pylint: disable-next=no-member
             if hasattr(e, "status_code") and e.status_code == "503":
                 raise MemphisError(
                     "Produce operation has failed, please check whether Station/Producer still exist"
                 )
-            else:
-                raise MemphisError(str(e)) from e
+            raise MemphisError(str(e)) from e
 
     async def destroy(self):
         """Destroy the producer."""


### PR DESCRIPTION
**Bug Fix for no-member error for Exception status_code member in which i have fixed the following erros**:

- `memphis/producer.py:210:45: E1101: Instance of 'Exception' has no 'status_code' member (no-member)`

and after fixing that, this error occured on the same line `269:12`:
-  `R1720: Unnecessary "else" after "raise", remove the "else" and de-indent the code inside it (no-else-raise)`

so, I also fixed that error and here's the final PR