### PR TITLE
avro validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ In cases where extra performance is needed the recommended way is to create a pr
 and produce messages by using the produce function of it
 ```python
 await memphis.produce(station_name='test_station_py', producer_name='prod_py',
-  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema) 
+  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema) or bytearray/dict (schema validated station - avro schema)
   generate_random_suffix=False, #defaults to false
   ack_wait_sec=15, # defaults to 15
   headers=headers, # default to {}
@@ -238,7 +238,7 @@ await memphis.produce(station_name='test_station_py', producer_name='prod_py',
 With creating a producer
 ```python
 await producer.produce(
-  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema)
+  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema) or or bytearray/dict (schema validated station - avro schema)
   ack_wait_sec=15) # defaults to 15
 ```
 
@@ -248,7 +248,7 @@ await producer.produce(
 headers= Headers()
 headers.add("key", "value")
 await producer.produce(
-  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema)
+  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema) or or bytearray/dict (schema validated station - avro schema)
   headers=headers) # default to {}
 ```
 
@@ -257,7 +257,7 @@ Meaning your application won't wait for broker acknowledgement - use only in cas
 
 ```python
 await producer.produce(
-  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema)
+  message='bytearray/protobuf class/dict/string/graphql.language.ast.DocumentNode', # bytearray / protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema) or or bytearray/dict (schema validated station - avro schema)
   headers={}, async_produce=True)
 ```
 

--- a/memphis/memphis.py
+++ b/memphis/memphis.py
@@ -48,6 +48,7 @@ class Memphis:
         self.proto_msgs = {}
         self.graphql_schemas = {}
         self.json_schemas = {}
+        self.avro_schemas = {}
         self.cluster_configurations = {}
         self.station_schemaverse_to_dls = {}
         self.update_configurations_sub = {}
@@ -449,6 +450,14 @@ class Memphis:
                             "active_version"
                         ]["schema_content"]
                     )
+                elif (
+                    self.schema_updates_data[internal_station_name]["type"] == "avro"
+                ):
+                    schema = self.schema_updates_data[internal_station_name][
+                        "active_version"
+                    ]["schema_content"]
+                    self.avro_schemas[internal_station_name] = json.loads(
+                        schema)
             producer = Producer(self, producer_name, station_name, real_name)
             map_key = internal_station_name + "_" + real_name
             self.producers_map[map_key] = producer
@@ -633,7 +642,7 @@ class Memphis:
         Args:
             station_name (str): station name to produce messages into.
             producer_name (str): name for the producer.
-            message (bytearray/dict): message to send into the station - bytearray/protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema)
+            message (bytearray/dict): message to send into the station - bytearray/protobuf class (schema validated station - protobuf) or bytearray/dict (schema validated station - json schema) or string/bytearray/graphql.language.ast.DocumentNode (schema validated station - graphql schema or  bytearray/dict (schema validated station - avro schema))
             generate_random_suffix (bool): false by default, if true concatenate a random suffix to producer's name
             ack_wait_sec (int, optional): max time in seconds to wait for an ack from memphis. Defaults to 15.
             headers (dict, optional): Message headers, defaults to {}.
@@ -729,11 +738,11 @@ class Memphis:
         """Creates a new schema.
         Args:.
             schema_name (str): the name of the schema.
-            schema_type (str): the type of the schema json / graphql / protobuf.
+            schema_type (str): the type of the schema json / graphql / protobuf / avro.
             schema_path (str): the path for the schema file
         """
 
-        if schema_type not in {'json', 'graphql', 'protobuf'}:
+        if schema_type not in {'json', 'graphql', 'protobuf', 'avro'}:
             raise MemphisError("schema type not supported" + type)
 
         try:

--- a/memphis/producer.py
+++ b/memphis/producer.py
@@ -10,10 +10,10 @@ from graphql import parse as parse_graphql
 from graphql import validate as validate_graphql
 from jsonschema import validate
 import google.protobuf.json_format as protobuf_json_format
+import fastavro
 from memphis.exceptions import MemphisError, MemphisSchemaError
 from memphis.headers import Headers
 from memphis.utils import get_internal_name
-import fastavro
 
 schemaverse_fail_alert_type = "schema_validation_fail_alert"
 
@@ -154,7 +154,7 @@ class Producer:
             if "Syntax Error" in str(e):
                 e = "Invalid message format, expected GraphQL"
             raise MemphisSchemaError("Schema validation has failed: " + str(e))
-        
+
     def validate_avro_schema(self, message):
         try:
             if isinstance(message, bytearray):
@@ -167,7 +167,7 @@ class Producer:
                 message = bytearray(json.dumps(message_obj).encode("utf-8"))
             else:
                 raise Exception("Unsupported message type")
-            
+
             fastavro.validate(
                 message_obj,
                 self.connection.avro_schemas[self.internal_station_name],

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     url="https://github.com/memphisdev/memphis.py",
     download_url="https://github.com/memphisdev/memphis.py/archive/refs/tags/1.0.6.tar.gz",
     keywords=["message broker", "devtool", "streaming", "data"],
-    install_requires=["asyncio", "nats-py", "protobuf", "jsonschema", "graphql-core"],
+    install_requires=["asyncio", "nats-py", "protobuf", "jsonschema", "graphql-core", "fastavro"],
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",


### PR DESCRIPTION
Related to https://github.com/memphisdev/memphis/pull/1107

I've used `https://github.com/fastavro/fastavro`  instead of `https://github.com/apache/avro` because of it's performance.
