### PR TITLE
stop consume functionality

### DIFF
--- a/memphis/consumer.py
+++ b/memphis/consumer.py
@@ -89,6 +89,11 @@ class Consumer:
         """
         self.dls_callback_func = callback
         self.t_consume = asyncio.create_task(self.__consume(callback))
+    
+    def stopConsume(self):
+        if self.t_consume is not None:
+            self.t_consume.cancel()
+            self.t_consume = None
 
     async def __consume(self, callback):
         subject = get_internal_name(self.station_name)


### PR DESCRIPTION
I have created a stopConsume method with self parameter, refefered in the issue #139 

```
def stopConsume(self):
    if self.t_consume is not None:
        self.t_consume.cancel()
        self.t_consume = None
```

**__In this code :__** 

- The stopConsume method is added to the Consumer class. This method will cancel the task responsible for consuming messages, effectively stopping the automatic message consumption.

- In the __consume method, we added a condition to check whether the consumer task (t_consume) is still running. If not, it will break out of the loop, ensuring that the consumption stops when stopConsume is called.